### PR TITLE
Fix: Correct stats and add separate trees for external dirs

### DIFF
--- a/export_repo/configs/test_external_dirs_config.json
+++ b/export_repo/configs/test_external_dirs_config.json
@@ -1,0 +1,15 @@
+{
+    "repo_root": "test_repo_main",
+    "export_name": "test_export_output.txt",
+    "output_dir": "test_output",
+    "dirs_to_traverse": ["subdir_repo"],
+    "include_top_level_files": "all",
+    "included_extensions": [".py", ".md", ".txt"],
+    "additional_dirs_to_traverse": [
+        "test_repo_external_1",
+        "test_repo_external_2"
+    ],
+    "always_exclude_patterns": ["test_export_output.txt"],
+    "dump_config": true,
+    "line_number_interval": 0
+}

--- a/test_output/test_export_output.txt
+++ b/test_output/test_export_output.txt
@@ -1,0 +1,205 @@
+<codebase_context>
+  <config source="export_repo/configs/test_external_dirs_config.json">
+{
+  "repo_root": "/app/test_repo_main",
+  "export_name": "test_export_output.txt",
+  "dirs_to_traverse": [
+    "subdir_repo"
+  ],
+  "include_top_level_files": "all",
+  "included_extensions": [
+    ".py",
+    ".md",
+    ".txt"
+  ],
+  "subdirs_to_exclude": [],
+  "files_to_exclude": [],
+  "depth": -1,
+  "dump_config": true,
+  "exhaustive_dir_tree": false,
+  "files_to_include": [],
+  "additional_dirs_to_traverse": [
+    "/app/test_repo_external_1",
+    "/app/test_repo_external_2"
+  ],
+  "always_exclude_patterns": [
+    "test_export_output.txt"
+  ],
+  "dirs_for_tree": [],
+  "line_number_interval": 0,
+  "line_number_min_length": 150,
+  "annotate_extensions": [
+    ".py",
+    ".js",
+    ".ts",
+    ".tsx",
+    ".java",
+    ".cpp",
+    ".c",
+    ".go",
+    ".rs",
+    ".sh",
+    ".sql"
+  ],
+  "line_number_prefix": "|LN|",
+  "comment_tokens_map": {
+    ".py": "#",
+    ".sh": "#",
+    ".rb": "#",
+    ".pl": "#",
+    ".yaml": "#",
+    ".yml": "#",
+    ".dockerfile": "#",
+    ".r": "#",
+    ".ps1": "#",
+    ".js": "//",
+    ".ts": "//",
+    ".tsx": "//",
+    ".java": "//",
+    ".c": "//",
+    ".cpp": "//",
+    ".h": "//",
+    ".hpp": "//",
+    ".cs": "//",
+    ".go": "//",
+    ".rs": "//",
+    ".kt": "//",
+    ".kts": "//",
+    ".scala": "//",
+    ".swift": "//",
+    ".php": "//",
+    ".sql": "--",
+    ".lua": "--",
+    ".hs": "--",
+    ".ada": "--"
+  },
+  "data_file_extensions": [
+    ".json",
+    ".xml",
+    ".tsv",
+    ".yaml",
+    ".toml",
+    ".csv",
+    ".yml"
+  ],
+  "blacklisted_dirs": [
+    "__pycache__",
+    ".git",
+    ".venv",
+    ".vscode",
+    "node_modules",
+    "build",
+    "dist"
+  ],
+  "blacklisted_files": [
+    "uv.lock",
+    "LICENSE",
+    ".DS_Store",
+    "*.pyc",
+    "*.swp",
+    "*.swo"
+  ],
+  "config_filename": "export_repo/configs/test_external_dirs_config.json",
+  "output_dir": "/app/test_output",
+  "output_file": "/app/test_output/test_export_output.txt",
+  "exported_files_count": {},
+  "total_lines": 24,
+  "total_tokens": 122,
+  "line_counts_by_file": {
+    "main_file.py": 5,
+    "subdir_repo/repo_subdir_file.txt": 2,
+    "/app/test_repo_external_1/external_file1.md": 3,
+    "/app/test_repo_external_1/ext1_subdir/external_py_file.py": 10,
+    "/app/test_repo_external_2/external_file2.txt": 4
+  },
+  "token_counts_by_file": {
+    "main_file.py": 19,
+    "subdir_repo/repo_subdir_file.txt": 15,
+    "/app/test_repo_external_1/external_file1.md": 16,
+    "/app/test_repo_external_1/ext1_subdir/external_py_file.py": 49,
+    "/app/test_repo_external_2/external_file2.txt": 23
+  },
+  "line_counts_by_dir": {
+    "subdir_repo": 2,
+    "": 7
+  },
+  "token_counts_by_dir": {
+    "subdir_repo": 15,
+    "": 34
+  },
+  "stats_by_extension": {
+    ".py": {
+      "files": 2,
+      "lines": 15,
+      "tokens": 68
+    },
+    ".txt": {
+      "files": 2,
+      "lines": 6,
+      "tokens": 38
+    },
+    ".md": {
+      "files": 1,
+      "lines": 3,
+      "tokens": 16
+    }
+  }
+}
+  </config>
+  <dirtree root="/app/test_repo_main">
+test_repo_main (7/34)
+||-- main_file.py (5 lines/19 tokens)
+|\-- subdir_repo (2/15)
+|    \-- repo_subdir_file.txt (2/15)
+  </dirtree>
+  <dirtree root="/app/test_repo_external_1">
+test_repo_external_1 (13/65)
+||-- ext1_subdir (10 lines/49 tokens)
+||   \-- external_py_file.py (10/49)
+|\-- external_file1.md (3/16)
+  </dirtree>
+  <dirtree root="/app/test_repo_external_2">
+test_repo_external_2 (4/23)
+|\-- external_file2.txt (4 lines/23 tokens)
+  </dirtree>
+  <files>
+    <file path="main_file.py">
+L1 python
+L2 python
+L3 python
+L4 python
+L5 python
+    </file>
+    <dir path="subdir_repo">
+      <file path="subdir_repo/repo_subdir_file.txt">
+L1 text in subdir_repo
+L2 text in subdir_repo
+      </file>
+    </dir>
+    <external_files>
+      <file path="/app/test_repo_external_1/ext1_subdir/external_py_file.py">
+L1 ext py
+L2 ext py
+L3 ext py
+L4 ext py
+L5 ext py
+L6 ext py
+L7 ext py
+L8 ext py
+L9 ext py
+L10 ext py
+      </file>
+      <file path="/app/test_repo_external_1/external_file1.md">
+# External MD L1
+## External MD L2
+External MD L3
+      </file>
+      <file path="/app/test_repo_external_2/external_file2.txt">
+External2 text L1
+External2 text L2
+External2 text L3
+External2 text L4
+      </file>
+    </external_files>
+  </files>
+</codebase_context>

--- a/test_repo_external_1/ext1_subdir/external_py_file.py
+++ b/test_repo_external_1/ext1_subdir/external_py_file.py
@@ -1,0 +1,10 @@
+L1 ext py
+L2 ext py
+L3 ext py
+L4 ext py
+L5 ext py
+L6 ext py
+L7 ext py
+L8 ext py
+L9 ext py
+L10 ext py

--- a/test_repo_external_1/external_file1.md
+++ b/test_repo_external_1/external_file1.md
@@ -1,0 +1,3 @@
+# External MD L1
+## External MD L2
+External MD L3

--- a/test_repo_external_2/external_file2.txt
+++ b/test_repo_external_2/external_file2.txt
@@ -1,0 +1,4 @@
+External2 text L1
+External2 text L2
+External2 text L3
+External2 text L4

--- a/test_repo_main/main_file.py
+++ b/test_repo_main/main_file.py
@@ -1,0 +1,5 @@
+L1 python
+L2 python
+L3 python
+L4 python
+L5 python

--- a/test_repo_main/subdir_repo/repo_subdir_file.txt
+++ b/test_repo_main/subdir_repo/repo_subdir_file.txt
@@ -1,0 +1,2 @@
+L1 text in subdir_repo
+L2 text in subdir_repo


### PR DESCRIPTION
This commit addresses two main issues with the export_repo tool:

1.  **Incorrect line/token counts for external directories:**
    - Files from directories specified in `additional_dirs_to_traverse` were not having their line and token counts correctly reflected in the overall summary and per-extension statistics.
    - This was primarily due to an issue where relative paths in `additional_dirs_to_traverse` were incorrectly resolved against the `repo_root` instead of the Current Working Directory (CWD). This path resolution has been fixed in `PathConverter.normalize_config_paths`.
    - Stat accumulation logic in `buffer_file_content` was confirmed to be working correctly once paths were properly resolved.

2.  **Feature: Separate directory trees for external directories:**
    - The tool now generates a distinct `<dirtree root="...">...</dirtree>` XML-like section for the main repository and for each directory listed in `additional_dirs_to_traverse`.
    - This involved refactoring `get_directory_tree` and its helper functions (`should_include_in_tree`, `get_stats_for_path`) to use a `tree_root_abs_path` parameter, allowing them to correctly generate trees and paths relative to different roots.
    - A new method `get_aggregated_stats_for_abs_dir` was implemented (renamed from a placeholder) to calculate total stats for any given absolute directory path, used for the root nodes of these trees.

Additionally, a minor bug was fixed where dumping the configuration to the export file would fail if the config contained `set` objects. These are now converted to lists before JSON serialization.

The changes have been tested with a configuration that includes external directories, verifying correct statistical aggregation, multiple tree generation, and overall output format.